### PR TITLE
Reworked Loader

### DIFF
--- a/gbfrelink.utility.manager/Mod.cs
+++ b/gbfrelink.utility.manager/Mod.cs
@@ -1,15 +1,18 @@
 ﻿using System.Buffers.Binary;
-using System.Diagnostics;
 using System.IO.Hashing;
 using System.Text;
-using FlatSharp;
-using GBFRDataTools;
-using GBFRDataTools.Entities;
+
 using Reloaded.Hooks.ReloadedII.Interfaces;
 using Reloaded.Mod.Interfaces;
+using Reloaded.Mod.Interfaces.Internal;
+
+using FlatSharp;
+
+using GBFRDataTools;
+using GBFRDataTools.Entities;
+
 using gbfrelink.utility.manager.Template;
 using gbfrelink.utility.manager.Configuration;
-using Reloaded.Mod.Interfaces.Internal;
 
 namespace gbfrelink.utility.manager;
 
@@ -50,8 +53,10 @@ public class Mod : ModBase // <= Do not Remove.
     private readonly IModConfig _modConfig;
 
     private IndexFile _index;
-
     private string _dataPath;
+
+    public const string INDEX_ORIGINAL_CODENAME = "relink";
+    public const string INDEX_MODDED_CODENAME = "relink-reloaded-ii-mod";
 
     public Mod(ModContext context)
     {
@@ -62,24 +67,155 @@ public class Mod : ModBase // <= Do not Remove.
         _configuration = context.Configuration;
         _modConfig = context.ModConfig;
 
-        // Copy original 
         string appLocation = _modLoader.GetAppConfig().AppLocation;
-        string dir = Path.GetDirectoryName(appLocation)!;
+        string gameDir = Path.GetDirectoryName(appLocation)!;
 
-        _dataPath = Path.Combine(dir, "data");
-        if (!Directory.Exists(_dataPath)) Directory.CreateDirectory(_dataPath);
+        // Create game's data/ directory if it doesn't exist already
+        // Admittedly if it doesn't exist the person should have bigger concerns since bgm & movies are external files in the first place
+        _dataPath = Path.Combine(gameDir, "data");
 
-        if (!File.Exists(Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId), "orig_data.i")))
-            File.Copy(Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId), "data.i"), Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId), "orig_data.i"));
-        
-        var origIndex = File.ReadAllBytes(Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId), "orig_data.i"));
-        _index = IndexFile.Serializer.Parse(origIndex);
+        if (!CreateGameDataDirectoryIfNeeded())
+            return;
 
-        // Ensure to start with a fresh base, Otherwise if all mods are unloaded, the modded data.i still stays
-        File.WriteAllBytes(Path.Combine(dir, "data.i"), origIndex);
+        if (!UpdateLocalDataIndex())
+            return;
+
+        if (!OverwriteGameDataIndexForCleanState())
+            return;
 
         _modLoader.ModLoading += ModLoading;
         _modLoader.ModLoaded += ModLoaded;
+
+        _logger.WriteLine("[GBFRelinkManager] GBFR Mod loader initialized.", _logger.ColorGreen);
+    }
+
+    /// <summary>
+    /// Creates the game's data/ directory if it's somehow missing.
+    /// </summary>
+    /// <returns>Whether the task was successful and the directory exists.</returns>
+    private bool CreateGameDataDirectoryIfNeeded()
+    {
+        if (!Directory.Exists(_dataPath))
+        {
+            try
+            {
+                Directory.CreateDirectory(_dataPath);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogError("ERROR: Game's data/ directory is missing and missing permissions to create it?");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                LogError($"ERROR: Unable to create game data/ directory - {ex.Message}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates a copy of the game's data index for local store.
+    /// </summary>
+    /// <returns>Whether the task is successful and local data.i is original & updated.</returns>
+    private bool UpdateLocalDataIndex()
+    {
+        string appLocation = _modLoader.GetAppConfig().AppLocation;
+        string gameDir = Path.GetDirectoryName(appLocation)!;
+
+        string modDir = Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId));
+        string gameDataIndexPath = Path.Combine(gameDir, "data.i");
+        string modLoaderDataIndexPath = Path.Combine(modDir, "orig_data.i");
+
+        if (!File.Exists(gameDataIndexPath))
+        {
+            LogError($"ERROR: Game's 'data.i' file does not exist. Ensure that this is not a mistake, or verify game files integrity.");
+            return false;
+        }
+
+        byte[] gameIndexFile = File.ReadAllBytes(gameDataIndexPath);
+        IndexFile gameIndex;
+        try
+        {
+            gameIndex = IndexFile.Serializer.Parse(gameIndexFile);
+        }
+        catch (Exception ex)
+        {
+            LogError($"ERROR: Unable to parse '{gameDataIndexPath}'. Corrupted or not supported? - {ex.Message}");
+            return false;
+        }
+
+        // Grab data.i from the game's folder. It'll be treated as the original we're storing locally
+        if (!File.Exists(modLoaderDataIndexPath))
+        {
+            // Two heuristics to check if this is an original index file:
+            // - 1. check codename. the mod loader will create an index with "relink-mod"
+            // - 2. check table offset in flatbuffers file. flatsharp serializes the vtable slightly differently with a negative offset, enough to spot a difference
+            //      this one is useful if the index has been tampered by GBFRDataTools from non-reloaded mods
+
+            if (gameIndex.Codename != INDEX_ORIGINAL_CODENAME)
+            {
+                LogError("ERROR: Game's 'data.i' appears to already be modded even though Reloaded II's data file is missing.");
+                LogError("Please verify game files integrity first.");
+                return false;
+            }
+            else if (BinaryPrimitives.ReadInt32LittleEndian(gameIndexFile.AsSpan(4)) != 0)
+            {
+                LogError("ERROR: Game's 'data.i' appears to already have been tampered with from outside the mod loader");
+                LogError("This can happen if you've installed mods that does not use the Reloaded II GBFR Mod Loader.");
+                LogError("This is unsupported and Reloaded II mods should be used instead. Verify integrity before using the mod loader.");
+                return false;
+            }
+        }
+        else
+        {
+            if (gameIndex.Codename != INDEX_ORIGINAL_CODENAME || BinaryPrimitives.ReadInt32LittleEndian(gameIndexFile.AsSpan(4)) != 0)
+                return true; // data.i is already modded. do not update local original copy.
+
+            LogInfo("Game's data.i is original & different from local copy. Updating it.");
+        }
+
+        try
+        {
+            File.Copy(gameDataIndexPath, modLoaderDataIndexPath, overwrite: true);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            LogError("ERROR: Could not copy game's data.i to mod loader's folder, missing permissions?");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            LogError($"ERROR: Could not copy game's data.i to mod loader's folder - {ex.Message}");
+            return false;
+        }
+        
+
+        return true;
+    }
+
+    /// <summary>
+    /// Overwrites the game's data index with the original one to start as a clean state without mods.
+    /// </summary>
+    /// <returns></returns>
+    private bool OverwriteGameDataIndexForCleanState()
+    {
+        string appLocation = _modLoader.GetAppConfig().AppLocation;
+        string gameDir = Path.GetDirectoryName(appLocation)!;
+
+        string modDir = Path.Combine(_modLoader.GetDirectoryForModId(_modConfig.ModId));
+        string gameDataIndexPath = Path.Combine(gameDir, "data.i");
+        string modLoaderDataIndexPath = Path.Combine(modDir, "orig_data.i");
+
+        var origIndex = File.ReadAllBytes(modLoaderDataIndexPath);
+        _index = IndexFile.Serializer.Parse(origIndex);
+
+        // Ensure to start with a fresh base, Otherwise if all mods are unloaded, the modded data.i still stays
+        File.WriteAllBytes(gameDataIndexPath, origIndex);
+
+        return true;
     }
 
     private void ModLoading(IModV1 mod, IModConfigV1 modConfig)
@@ -111,30 +247,14 @@ public class Mod : ModBase // <= Do not Remove.
 
             long fileSize = new FileInfo(file).Length;
             if (AddOrUpdateExternalFile(hash, (ulong)fileSize))
-                Console.WriteLine($"- Index: Added {str} as new external file");
+                LogInfo($"- {modConfig.ModId}: Added {str} as new external file");
             else
-                Console.WriteLine($"- Index: Updated {str} external file");
+                LogInfo($"- {modConfig.ModId}: Updated {str} external file");
             RemoveArchiveFile(hash);
         }
 
-        string[] files2 = Directory.GetFiles(_dataPath, "*", SearchOption.AllDirectories);
-        foreach (var file in files2)
-        {
-            if (file.Contains("sound")) continue;
-            string str = file[(_dataPath.Length + 1)..].Replace('\\', '/');
-
-            byte[] hashBytes = XxHash64.Hash(Encoding.ASCII.GetBytes(str), 0);
-            ulong hash = BinaryPrimitives.ReadUInt64BigEndian(hashBytes);
-
-            int idx = _index.ExternalFileHashes.BinarySearch(hash);
-            if (idx < 0)
-            {
-                File.Delete(file);
-            }
-        }
-
-        Console.WriteLine();
-        Console.WriteLine($"-> {files.Length} files have been added or updated to the external file list.");
+        LogInfo("");
+        LogInfo($"-> {files.Length} files have been added or updated to the external file list.");
     }
 
     private bool AddOrUpdateExternalFile(ulong hash, ulong fileSize)
@@ -169,9 +289,29 @@ public class Mod : ModBase // <= Do not Remove.
     private void ModLoaded(IModV1 arg1, IModConfigV1 arg2)
     {
         byte[] outBuf = new byte[IndexFile.Serializer.GetMaxSize(_index)];
+        _index.Codename = INDEX_MODDED_CODENAME; // Helps us keep of track whether this is an original index or not
+
         IndexFile.Serializer.Write(outBuf, _index);
         File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(_modLoader.GetAppConfig().AppLocation)!, "data.i"), outBuf);
     }
+
+
+    private void LogInfo(string str)
+    {
+        _logger.WriteLine($"[GBFRelinkManager] {str}");
+    }
+
+    private void LogError(string str)
+    {
+        _logger.WriteLine($"[GBFRelinkManager] {str}", _logger.ColorRed);
+    }
+
+    private void LogSuccess(string str)
+    {
+        _logger.WriteLine($"[GBFRelinkManager] {str}", _logger.ColorGreen);
+    }
+
+
 
     #region Standard Overrides
 

--- a/gbfrelink.utility.manager/Mod.cs
+++ b/gbfrelink.utility.manager/Mod.cs
@@ -151,7 +151,7 @@ public class Mod : ModBase // <= Do not Remove.
         if (!File.Exists(modLoaderDataIndexPath))
         {
             // Two heuristics to check if this is an original index file:
-            // - 1. check codename. the mod loader will create an index with "relink-mod"
+            // - 1. check codename. the mod loader will create an index with "relink-reloaded-ii-mod"
             // - 2. check table offset in flatbuffers file. flatsharp serializes the vtable slightly differently with a negative offset, enough to spot a difference
             //      this one is useful if the index has been tampered by GBFRDataTools from non-reloaded mods
 


### PR DESCRIPTION
Last commit broke the loader - A file was being copied when it didn't necessarily exist. Prompted me to just rework the whole thing.

* Checks. Added checks almost everywhere.
* Logging messages.
* Original `data.i` copying to local loader will only occur if the game's `data.i` is actually original: 
  * By checking if its codename has been tampered with - the mod loader will now change it as a way to determine whether the last edit was a loader edit
  * By checking if the offset at 0x04 of the flatbuffers file is not zero - this is a cool hack since FlatSharp does its vtable serialization differently than original, therefore makes GBFRDataTools-built files detectable.
* Do not delete any files even if they're not registered in the index - some modders were complaining that their work were erased

This will require some more further testing but from my initial tests, everything works correctly.