### PR TITLE
fix issue with updating external file located on mixed-case path

### DIFF
--- a/gbfrelink.utility.manager/Mod.cs
+++ b/gbfrelink.utility.manager/Mod.cs
@@ -253,7 +253,7 @@ public class Mod : ModBase // <= Do not Remove.
         string[] files = Directory.GetFiles(folder, "*", SearchOption.AllDirectories);
         foreach (var file in files)
         {
-            string str = file[(folder.Length + 1)..].Replace('\\', '/');
+            string str = file[(folder.Length + 1)..].Replace('\\', '/').ToLower();
 
             byte[] hashBytes = XxHash64.Hash(Encoding.ASCII.GetBytes(str), 0);
             ulong hash = BinaryPrimitives.ReadUInt64BigEndian(hashBytes);


### PR DESCRIPTION
Because the GBFR takes lowercase filepath as the input of hash function, not original filepath (may mixed-case).

Hence, 
current tool-chain will add new external record, not update existing record what we expected in index-file.